### PR TITLE
Make AsyncTasks parallel on API 11+

### DIFF
--- a/app/src/main/java/inaka/com/tinytask/TinyTask.java
+++ b/app/src/main/java/inaka/com/tinytask/TinyTask.java
@@ -44,7 +44,11 @@ public class TinyTask<T> {
     public void go() {
         if(genericTask == null) {
             genericTask = new GenericTask<>(this);
-            genericTask.execute();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+                genericTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+            } else {
+                genericTask.execute();
+            }
         }
     }
 


### PR DESCRIPTION
According to the examination of the source code to AsyncTask, on pre-Honeycomb all of the AsyncTasks were executed on a thread pool with a minimum of 5 threads and a maximum of 128. But on API 11+, it won't be executed on a thread pool unless you call executeOnExecutor() with the corresponding argument.
Source: http://developer.android.com/reference/android/os/AsyncTask.html
